### PR TITLE
(Hopefully) fix build with FFMPEG 5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     container: jrottenberg/ffmpeg:${{ matrix.ffmpeg_version }}-ubuntu
     strategy:
       matrix:
-        ffmpeg_version: ["3.4", "4.0", "4.1", "4.2", "4.3", "4.4", "5.0"]
+        ffmpeg_version: ["3.4", "4.0", "4.1", "4.2", "4.3", "4.4", "5.0", "5.1"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ffmpeg-next"
-version = "5.0.3"
+version = "5.1.1"
 build   = "build.rs"
 
 authors = ["meh. <meh@schizofreni.co>", "Zhiming Wang <i@zhimingwang.org>"]
@@ -113,5 +113,5 @@ version  = "0.23"
 optional = true
 
 [dependencies.ffmpeg-sys-next]
-version = "5.0.1"
+version = "5.1.1"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ffmpeg-next"
-version = "5.0.2"
+version = "5.0.3"
 build   = "build.rs"
 
 authors = ["meh. <meh@schizofreni.co>", "Zhiming Wang <i@zhimingwang.org>"]

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -13,7 +13,7 @@ pub enum Id {
     // video codecs
     MPEG1VIDEO,
     MPEG2VIDEO,
-    #[cfg(feature = "ff_api_xvmc")]
+    #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
     MPEG2VIDEO_XVMC,
     H261,
     H263,
@@ -602,6 +602,17 @@ pub enum Id {
     ADPCM_IMA_ACORN,
     #[cfg(feature = "ffmpeg_5_0")]
     MSNSIREN,
+
+    #[cfg(feature = "ffmpeg_5_1")]
+    VBN,
+    #[cfg(feature = "ffmpeg_5_1")]
+    JPEGXL,
+    #[cfg(feature = "ffmpeg_5_1")]
+    QOI,
+    #[cfg(feature = "ffmpeg_5_1")]
+    PHM,
+    #[cfg(feature = "ffmpeg_5_1")]
+    DFPWM,
 }
 
 impl Id {
@@ -625,7 +636,7 @@ impl From<AVCodecID> for Id {
             /* video codecs */
             AV_CODEC_ID_MPEG1VIDEO => Id::MPEG1VIDEO,
             AV_CODEC_ID_MPEG2VIDEO => Id::MPEG2VIDEO,
-            #[cfg(feature = "ff_api_xvmc")]
+            #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
             AV_CODEC_ID_MPEG2VIDEO_XVMC => Id::MPEG2VIDEO_XVMC,
             AV_CODEC_ID_H261 => Id::H261,
             AV_CODEC_ID_H263 => Id::H263,
@@ -1211,6 +1222,17 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_ADPCM_IMA_ACORN => Id::ADPCM_IMA_ACORN,
             #[cfg(feature = "ffmpeg_5_0")]
             AV_CODEC_ID_MSNSIREN => Id::MSNSIREN,
+
+            #[cfg(feature = "ffmpeg_5_1")]
+            AV_CODEC_ID_VBN => Id::VBN,
+            #[cfg(feature = "ffmpeg_5_1")]
+            AV_CODEC_ID_JPEGXL => Id::JPEGXL,
+            #[cfg(feature = "ffmpeg_5_1")]
+            AV_CODEC_ID_QOI => Id::QOI,
+            #[cfg(feature = "ffmpeg_5_1")]
+            AV_CODEC_ID_PHM => Id::PHM,
+            #[cfg(feature = "ffmpeg_5_1")]
+            AV_CODEC_ID_DFPWM => Id::DFPWM,
         }
     }
 }
@@ -1223,7 +1245,7 @@ impl From<Id> for AVCodecID {
             /* video codecs */
             Id::MPEG1VIDEO => AV_CODEC_ID_MPEG1VIDEO,
             Id::MPEG2VIDEO => AV_CODEC_ID_MPEG2VIDEO,
-            #[cfg(feature = "ff_api_xvmc")]
+            #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
             Id::MPEG2VIDEO_XVMC => AV_CODEC_ID_MPEG2VIDEO_XVMC,
             Id::H261 => AV_CODEC_ID_H261,
             Id::H263 => AV_CODEC_ID_H263,
@@ -1812,6 +1834,17 @@ impl From<Id> for AVCodecID {
             Id::ADPCM_IMA_ACORN => AV_CODEC_ID_ADPCM_IMA_ACORN,
             #[cfg(feature = "ffmpeg_5_0")]
             Id::MSNSIREN => AV_CODEC_ID_MSNSIREN,
+
+            #[cfg(feature = "ffmpeg_5_1")]
+            Id::VBN => AV_CODEC_ID_VBN,
+            #[cfg(feature = "ffmpeg_5_1")]
+            Id::JPEGXL => AV_CODEC_ID_JPEGXL,
+            #[cfg(feature = "ffmpeg_5_1")]
+            Id::QOI => AV_CODEC_ID_QOI,
+            #[cfg(feature = "ffmpeg_5_1")]
+            Id::PHM => AV_CODEC_ID_PHM,
+            #[cfg(feature = "ffmpeg_5_1")]
+            Id::DFPWM => AV_CODEC_ID_DFPWM,
         }
     }
 }

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -24,7 +24,7 @@ pub use libc::{
     EWOULDBLOCK, EXDEV,
 };
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Error {
     Bug,
     Bug2,

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -25,9 +25,9 @@ pub enum Pixel {
     YUVJ420P,
     YUVJ422P,
     YUVJ444P,
-    #[cfg(feature = "ff_api_xvmc")]
+    #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
     XVMC_MPEG2_MC,
-    #[cfg(feature = "ff_api_xvmc")]
+    #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
     XVMC_MPEG2_IDCT,
     UYVY422,
     UYYVYY411,
@@ -222,7 +222,7 @@ pub enum Pixel {
     VIDEOTOOLBOX,
 
     // --- defaults
-    #[cfg(not(feature = "ff_api_xvmc"))]
+    #[cfg(feature = "ffmpeg_4_0")]
     XVMC,
 
     RGB32,
@@ -394,7 +394,7 @@ impl Pixel {
     pub const Y400A: Pixel = Pixel::YA8;
     pub const GRAY8A: Pixel = Pixel::YA8;
     pub const GBR24P: Pixel = Pixel::GBRP;
-    #[cfg(feature = "ff_api_xvmc")]
+    #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
     pub const XVMC: Pixel = Pixel::XVMC_MPEG2_IDCT;
 
     pub fn descriptor(self) -> Option<Descriptor> {
@@ -449,11 +449,11 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_YUVJ420P => Pixel::YUVJ420P,
             AV_PIX_FMT_YUVJ422P => Pixel::YUVJ422P,
             AV_PIX_FMT_YUVJ444P => Pixel::YUVJ444P,
-            #[cfg(not(feature = "ff_api_xvmc"))]
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_PIX_FMT_XVMC => Pixel::XVMC,
-            #[cfg(feature = "ff_api_xvmc")]
+            #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
             AV_PIX_FMT_XVMC_MPEG2_MC => Pixel::XVMC_MPEG2_MC,
-            #[cfg(feature = "ff_api_xvmc")]
+            #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
             AV_PIX_FMT_XVMC_MPEG2_IDCT => Pixel::XVMC_MPEG2_IDCT,
             AV_PIX_FMT_UYVY422 => Pixel::UYVY422,
             AV_PIX_FMT_UYYVYY411 => Pixel::UYYVYY411,
@@ -767,9 +767,9 @@ impl From<Pixel> for AVPixelFormat {
             Pixel::YUVJ420P => AV_PIX_FMT_YUVJ420P,
             Pixel::YUVJ422P => AV_PIX_FMT_YUVJ422P,
             Pixel::YUVJ444P => AV_PIX_FMT_YUVJ444P,
-            #[cfg(feature = "ff_api_xvmc")]
+            #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
             Pixel::XVMC_MPEG2_MC => AV_PIX_FMT_XVMC_MPEG2_MC,
-            #[cfg(feature = "ff_api_xvmc")]
+            #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
             Pixel::XVMC_MPEG2_IDCT => AV_PIX_FMT_XVMC_MPEG2_IDCT,
             Pixel::UYVY422 => AV_PIX_FMT_UYVY422,
             Pixel::UYYVYY411 => AV_PIX_FMT_UYYVYY411,
@@ -964,7 +964,7 @@ impl From<Pixel> for AVPixelFormat {
             Pixel::VIDEOTOOLBOX => AV_PIX_FMT_VIDEOTOOLBOX,
 
             // --- defaults
-            #[cfg(not(feature = "ff_api_xvmc"))]
+            #[cfg(feature = "ffmpeg_4_0")]
             Pixel::XVMC => AV_PIX_FMT_XVMC,
 
             Pixel::RGB32 => AV_PIX_FMT_RGB32,

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -55,6 +55,9 @@ pub enum Type {
     DOVI_RPU_BUFFER,
     #[cfg(feature = "ffmpeg_5_0")]
     DOVI_METADATA,
+
+    #[cfg(feature = "ffmpeg_5_1")]
+    DYNAMIC_HDR_VIVID,
 }
 
 impl Type {
@@ -114,6 +117,9 @@ impl From<AVFrameSideDataType> for Type {
             AV_FRAME_DATA_DOVI_RPU_BUFFER => Type::DOVI_RPU_BUFFER,
             #[cfg(feature = "ffmpeg_5_0")]
             AV_FRAME_DATA_DOVI_METADATA => Type::DOVI_METADATA,
+
+            #[cfg(feature = "ffmpeg_5_1")]
+            AV_FRAME_DATA_DYNAMIC_HDR_VIVID => Type::DYNAMIC_HDR_VIVID,
         }
     }
 }
@@ -166,6 +172,9 @@ impl From<Type> for AVFrameSideDataType {
             Type::DOVI_RPU_BUFFER => AV_FRAME_DATA_DOVI_RPU_BUFFER,
             #[cfg(feature = "ffmpeg_5_0")]
             Type::DOVI_METADATA => AV_FRAME_DATA_DOVI_METADATA,
+
+            #[cfg(feature = "ffmpeg_5_1")]
+            Type::DYNAMIC_HDR_VIVID => AV_FRAME_DATA_DYNAMIC_HDR_VIVID,
         }
     }
 }

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -51,6 +51,8 @@ impl From<AVOptionType> for Type {
             AV_OPT_TYPE_DURATION => Type::Duration,
             AV_OPT_TYPE_COLOR => Type::Color,
             AV_OPT_TYPE_CHANNEL_LAYOUT => Type::ChannelLayout,
+            #[cfg(feature = "ffmpeg_5_1")]
+            AV_OPT_TYPE_CHLAYOUT => Type::ChannelLayout,
         }
     }
 }


### PR DESCRIPTION
Build is broken because of some Codec ID mappings that changed / got removed.

```
error[E0425]: cannot find value `AV_CODEC_ID_MPEG2VIDEO_XVMC` in this scope
    --> /home/peet/.cargo/git/checkouts/rust-ffmpeg-5823081afb649100/22897a7/src/codec/id.rs:1227:36
     |
1227 |             Id::MPEG2VIDEO_XVMC => AV_CODEC_ID_MPEG2VIDEO_XVMC,
     |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a unit variant with a similar name exists: `AV_CODEC_ID_MPEG2VIDEO`
     |
    ::: /home/peet/Documents/Privat/Rust/Leierkasten/target/release/build/ffmpeg-sys-next-c0a4249427477b84/out/bindings.rs:7828:5
     |
7828 |     AV_CODEC_ID_MPEG2VIDEO = 2,
     |     ---------------------- similarly named unit variant `AV_CODEC_ID_MPEG2VIDEO` defined here
```

It looks to me like it is fixed by https://github.com/jwiesler/rust-ffmpeg/commit/b6b2311fcf9351e123d586dae6f3772dcc133701